### PR TITLE
Tag build releases

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+[*]
+
+# Change these settings to your own preference
+indent_style = tab
+indent_size = 2
+
+# We recommend you to keep these unchanged
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/tasks/tagrelease.js
+++ b/tasks/tagrelease.js
@@ -119,8 +119,12 @@ module.exports = function(grunt) {
 		}
 
 		// Validate new version
+		var buildMeta = newVersion.split('+')[1]
 		if (semver.valid(newVersion)) {
 			newVersion = semver.valid(newVersion);
+			if (buildMeta) {
+				newVersion += '+' + buildMeta;
+			}
 		} else {
 			failed('"' + newVersion + '" is not a valid semantic version.');
 			return;
@@ -139,7 +143,7 @@ module.exports = function(grunt) {
 		var highestTag = git.getHighestTag();
 
 		// Check whether the new tag is higher than the current highest tag
-		if (highestTag && !semver.gt(newVersion, highestTag)) {
+		if (!buildMeta && highestTag && !semver.gt(newVersion, highestTag)) {
 			failed('Version "' + newVersion + '" is lower or equal than the current highest tag "' + highestTag + '".');
 			return;
 		}

--- a/tasks/tagrelease.js
+++ b/tasks/tagrelease.js
@@ -119,7 +119,7 @@ module.exports = function(grunt) {
 		}
 
 		// Validate new version
-		var buildMeta = newVersion.split('+')[1]
+		var buildMeta = newVersion.split('+')[1];
 		if (semver.valid(newVersion)) {
 			newVersion = semver.valid(newVersion);
 			if (buildMeta) {

--- a/test/metafile.json
+++ b/test/metafile.json
@@ -1,5 +1,5 @@
 {
 	"name": "pkg-name",
 	"description": "Description.",
-	"version": "0.2.0"
+	"version": "0.4.0"
 }


### PR DESCRIPTION
After [adding support for bumping builds](https://github.com/darsain/grunt-bumpup/pull/7), it would be nice to tag those builds. This captures the build metadata like [node-semver does](https://github.com/isaacs/node-semver/blob/master/semver.js#L91-L97) and skips validation on whether the new version is higher than the highest tag if your version includes build metadata.

I also added a boilerplate editorconfig file since it was mentioned in the [contributing doc](https://github.com/darsain/grunt-tagrelease/blob/master/CONTRIBUTING.md) but not in the repo.
